### PR TITLE
skip taint tests on portable perl

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 Revision history for Devel-FindPerl
 
 {{$NEXT}}
-
+     Skip taint tests on portable Strawberry Perl.
 0.012     2013-11-20 14:57:15 Europe/Amsterdam
           Minor fixes in tests
 

--- a/t/11-tainted.t
+++ b/t/11-tainted.t
@@ -11,6 +11,7 @@ use Devel::FindPerl qw/find_perl_interpreter perl_is_same/;
 my $perlpath = $Config{perlpath};
 plan(skip_all => 'Taint test can\'t be run from uninstalled perl') if $ENV{PERL_CORE};
 plan(skip_all => 'Taint test can\'t be run for relocatable perl') if $Config{userelocatableinc};
+plan(skip_all => 'Taint test can\'t be run for portable perl') if eval "require Portable";
 plan(skip_all => "Perl not in perlpath '$perlpath'") unless -x $perlpath and perl_is_same($perlpath);
 plan(skip_all => 'Testrun without taint mode') if not $^T;
 


### PR DESCRIPTION
Add a new `skip_all` condition that successfully detects the use of
portable Strawberry Perl, allowing a clean install to portable
Strawberry and berrybrew installations.

Fixes RT #97370.
