### PR TITLE
Import `splitpath` before using

### DIFF
--- a/lib/Devel/FindPerl.pm
+++ b/lib/Devel/FindPerl.pm
@@ -10,7 +10,7 @@ use Carp q/carp/;
 use Config;
 use Cwd q/realpath/;
 use File::Basename qw/basename dirname/;
-use File::Spec::Functions qw/catfile catdir rel2abs file_name_is_absolute updir curdir path/;
+use File::Spec::Functions qw/catfile catdir rel2abs file_name_is_absolute updir curdir path splitpath/;
 use Scalar::Util 'tainted';
 use IPC::Open2 qw/open2/;
 


### PR DESCRIPTION
Tests were dieing:

    Undefined subroutine &Devel::FindPerl::splitpath called at lib/Devel/FindPerl.pm line 34.