### PR TITLE
delete %ENV entries after localizing them to bypass taint

### DIFF
--- a/lib/Devel/FindPerl.pm
+++ b/lib/Devel/FindPerl.pm
@@ -116,6 +116,7 @@ sub _capture_command {
 	my (@command) = @_;
 
 	local @ENV{qw/PATH IFS CDPATH ENV BASH_ENV/};
+	delete @ENV{qw/PATH IFS CDPATH ENV BASH_ENV/};
 	my $pid = open2(my($in, $out), @command);
 	binmode $in, ':crlf' if $^O eq 'MSWin32';
 	my $ret = do { local $/; <$in> };


### PR DESCRIPTION
Doing local $ENV{$var} localizes the environment variable, but also sets
it to undef, which for an env var means setting it to an empty string.
Some environment variables are problematic when set to an empty string.
For example, an empty PATH is equivalent to '.', the current directory,
which makes it vulnerable to anything in the current directory. Future
versions of perl will complain about a PATH set to an empty string or
undef when run under taint mode.

Deleting PATH after localizing it will avoid this problem. For
consistency, just delete all of the env vars.